### PR TITLE
Update getfood.php

### DIFF
--- a/getfood.php
+++ b/getfood.php
@@ -357,6 +357,7 @@
   // parse plans
   $t = 0;
   foreach ( $plansXML as $planXML ) {
+    if (!file_exists($planXML)) continue;       // sometimes there is no xml b/c there were invalid pdf-links
     preg_match_all('/\d+/', $plans[$t], $matches);
     $calendarWeek = array_pop($matches[0]);
     $year = date("Y",time());


### PR DESCRIPTION
Sometimes, not all found links to the PDFs are valid => wget creates a pdf with 0 byte => no *.xml will be created => xml parser chokes => PHP exits.
This fix checks if there was a xml-file generated
